### PR TITLE
Phpcr does not handle DateTimeImmutable objects

### DIFF
--- a/src/ODM/PhpCr/Timestampable/TimestampableTrait.php
+++ b/src/ODM/PhpCr/Timestampable/TimestampableTrait.php
@@ -2,9 +2,16 @@
 
 namespace Refugis\DoctrineExtra\ODM\PhpCr\Timestampable;
 
+use Cake\Chronos\MutableDateTime;
 use Doctrine\ODM\PHPCR\Mapping\Annotations as ODM;
+use Refugis\DoctrineExtra\Timestampable\TimestampableInterface;
 use Refugis\DoctrineExtra\Timestampable\TimestampableTrait as BaseTrait;
 
+/**
+ * Unfortunately PHPCR only supports mutable DateTime objects.
+ * Set property types to mutable DateTime to avoid errors during initialization,
+ * but return immutable object from getters.
+ */
 trait TimestampableTrait
 {
     use BaseTrait;
@@ -12,10 +19,36 @@ trait TimestampableTrait
     /**
      * @ODM\Field(type="date")
      */
-    private \DateTimeInterface $createdAt;
+    private \DateTime $createdAt;
 
     /**
      * @ODM\Field(type="date")
      */
-    private \DateTimeInterface $updatedAt;
+    private \DateTime $updatedAt;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return \DateTimeImmutable::createFromMutable($this->createdAt);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUpdatedAt(): \DateTimeInterface
+    {
+        return \DateTimeImmutable::createFromMutable($this->updatedAt);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateTimestamp(): TimestampableInterface
+    {
+        $this->updatedAt = MutableDateTime::now();
+
+        return $this;
+    }
 }


### PR DESCRIPTION
PHPCR only supports mutable DateTime objects, but TimestampableTrait always sets `updatedAt` to an instance of `DateTimeImmutable`. This should work around this problem.

I've set property types to mutable DateTime to avoid errors during initialization, but I think we should return immutable object from getters.