### PR TITLE
Support PHP 8.1 and native enums

### DIFF
--- a/.github/workflows/cscheck.yml
+++ b/.github/workflows/cscheck.yml
@@ -2,8 +2,8 @@ name: Check CS
 
 on:
     push:
-    pull_request:
-        types: [opened]
+    pull_request_target:
+        types: [opened, synchronize]
 
 jobs:
     build:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,8 +2,8 @@ name: PHPStan
 
 on:
     push:
-    pull_request:
-        types: [opened]
+    pull_request_target:
+        types: [opened, synchronize]
 
 jobs:
     build:
@@ -18,7 +18,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     coverage: none
-                    php-version: "8.0"
+                    php-version: "8.1"
                     tools: cs2pr
 
             -   name: Install dependencies with composer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
             matrix:
                 composer_flags:
                     - ''
-                    - '--prefer-lowest'
 
                 php_version:
                     - '7.4'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
-on: [push, pull_request]
+on:
+    push:
+    pull_request:
+        types: [opened, synchronize]
 
 jobs:
     build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 on:
     push:
-    pull_request:
+    pull_request_target:
         types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
                 php_version:
                     - '7.4'
                     - '8.0'
+                    - '8.1'
 
         name: PHP ${{ matrix.php_version }}
         steps:

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require-dev": {
         "composer-runtime-api": "^2",
         "cakephp/chronos": "^1.2",
+        "doctrine/dbal": "^3.2",
         "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.7",
         "doctrine/phpcr-odm": "^1.5",
@@ -40,7 +41,7 @@
         "refugis/elastica-odm": "^2.0@dev",
         "roave/security-advisories": "dev-master",
         "solido/php-coding-standards": "dev-master",
-        "symfony/cache": "^4.2 || ^5.0"
+        "symfony/cache": "^4.2 || ^5.0 || ^6.0"
     },
     "autoload": {
         "files": [ "compat/compat.php" ],

--- a/src/DBAL/RowIterator.php
+++ b/src/DBAL/RowIterator.php
@@ -7,6 +7,7 @@ namespace Refugis\DoctrineExtra\DBAL;
 use ArrayIterator;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Refugis\DoctrineExtra\ObjectIteratorInterface;
+use ReturnTypeWillChange;
 
 class RowIterator implements ObjectIteratorInterface
 {
@@ -51,6 +52,7 @@ class RowIterator implements ObjectIteratorInterface
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $this->getIterator();

--- a/src/IteratorTrait.php
+++ b/src/IteratorTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Refugis\DoctrineExtra;
 
+use ReturnTypeWillChange;
+
 use function call_user_func;
 
 trait IteratorTrait
@@ -49,6 +51,7 @@ trait IteratorTrait
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         if (! $this->valid()) {

--- a/src/ORM/EntityIterator.php
+++ b/src/ORM/EntityIterator.php
@@ -9,6 +9,7 @@ use Generator;
 use InvalidArgumentException;
 use Iterator;
 use Refugis\DoctrineExtra\ObjectIteratorInterface;
+use ReturnTypeWillChange;
 
 use function assert;
 use function count;
@@ -75,6 +76,7 @@ class EntityIterator implements ObjectIteratorInterface
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $this->getIterator();

--- a/src/ORM/EntityRepository.php
+++ b/src/ORM/EntityRepository.php
@@ -17,6 +17,7 @@ use function is_array;
 use function method_exists;
 use function serialize;
 use function sha1;
+use function str_replace;
 
 /**
  * @template T of object
@@ -25,6 +26,8 @@ use function sha1;
  */
 class EntityRepository extends BaseRepository implements ObjectRepositoryInterface
 {
+    private const INVALID_CACHE_KEY_CHARS = ['{', '}', '(', ')', '/', '\\', '@', ':'];
+
     public function all(): ObjectIteratorInterface
     {
         return new EntityIterator($this->createQueryBuilder('a'));
@@ -49,7 +52,7 @@ class EntityRepository extends BaseRepository implements ObjectRepositoryInterfa
         $query = $this->buildQueryForFind($criteria, $orderBy);
         $query->setMaxResults(1);
 
-        $cacheKey = '__' . static::class . '::' . __FUNCTION__ . sha1(serialize(func_get_args()));
+        $cacheKey = str_replace(self::INVALID_CACHE_KEY_CHARS, '', '__' . static::class . '::' . __FUNCTION__ . sha1(serialize(func_get_args())));
         if (method_exists($query, 'enableResultCache')) {
             $query->enableResultCache($ttl, $cacheKey);
         } else {
@@ -82,7 +85,7 @@ class EntityRepository extends BaseRepository implements ObjectRepositoryInterfa
             $query->setFirstResult($offset);
         }
 
-        $cacheKey = '__' . static::class . '::' . __FUNCTION__ . sha1(serialize(func_get_args()));
+        $cacheKey = str_replace(self::INVALID_CACHE_KEY_CHARS, '', '__' . static::class . '::' . __FUNCTION__ . sha1(serialize(func_get_args())));
         if (method_exists($query, 'enableResultCache')) {
             $query->enableResultCache($ttl, $cacheKey);
         } else {
@@ -126,7 +129,7 @@ class EntityRepository extends BaseRepository implements ObjectRepositoryInterfa
         $query = $this->buildQueryForFind($criteria, $orderBy);
         $query->setMaxResults(1);
 
-        $cacheKey = '__' . static::class . '::' . __FUNCTION__ . sha1(serialize(func_get_args()));
+        $cacheKey = str_replace(self::INVALID_CACHE_KEY_CHARS, '', '__' . static::class . '::' . __FUNCTION__ . sha1(serialize(func_get_args())));
         if (method_exists($query, 'enableResultCache')) {
             $query->enableResultCache($ttl, $cacheKey);
         } else {

--- a/src/ORM/Metadata/ClassMetadata.php
+++ b/src/ORM/Metadata/ClassMetadata.php
@@ -70,6 +70,11 @@ class ClassMetadata extends BaseClassMetadata
      */
     public function inlineEmbeddable($property, ClassMetadataInfo $embeddable): void
     {
+        $reflectionClass = $this->reflClass;
+
+        assert($reflectionClass !== null);
+        assert($embeddable->reflClass !== null);
+
         foreach ($embeddable->fieldMappings as $fieldMapping) {
             $fieldMapping['originalClass'] ??= $embeddable->name;
             $fieldMapping['declaredField'] = isset($fieldMapping['declaredField']) ? $property . '.' . $fieldMapping['declaredField'] : $property;
@@ -84,7 +89,7 @@ class ClassMetadata extends BaseClassMetadata
                     ->embeddedFieldToColumnName(
                         $property,
                         $fieldMapping['columnName'],
-                        $this->reflClass->name,
+                        $reflectionClass->name,
                         $embeddable->reflClass->name
                     );
             }
@@ -114,7 +119,7 @@ class ClassMetadata extends BaseClassMetadata
                         ->embeddedFieldToColumnName(
                             $property,
                             $column['name'],
-                            $this->reflClass->name,
+                            $reflectionClass->name,
                             $embeddable->reflClass->name
                         );
                 }

--- a/src/ORM/Type/PhpEnumType.php
+++ b/src/ORM/Type/PhpEnumType.php
@@ -124,15 +124,15 @@ class PhpEnumType extends Type
                 $toPhp = function ($enumValue) use ($enumClass): BackedEnum {
                     $val = $enumClass::tryFrom($enumValue);
                     if ($val === null) {
-                        throw ConversionException::conversionFailed($enumValue, $this->name);
+                        throw ConversionException::conversionFailed($enumValue, $this->name); /* @phpstan-ignore-line */
                     }
 
                     return $val;
                 };
 
                 $toDatabase = function (BackedEnum $enum) {
-                    if (! $enum instanceof $this->enumClass) {
-                        throw ConversionException::conversionFailedInvalidType($enum, $this->name, [$this->enumClass]);
+                    if (! $enum instanceof $this->enumClass) { /* @phpstan-ignore-line */
+                        throw ConversionException::conversionFailedInvalidType($enum, $this->name, [$this->enumClass]); /* @phpstan-ignore-line */
                     }
 
                     return $enum->value;
@@ -143,15 +143,15 @@ class PhpEnumType extends Type
                     try {
                         $case = $reflection->getCase($enumValue);
                     } catch (ReflectionException $e) {
-                        throw ConversionException::conversionFailed($enumValue, $this->name, $e);
+                        throw ConversionException::conversionFailed($enumValue, $this->name, $e); /* @phpstan-ignore-line */
                     }
 
                     return $case->getValue();
                 };
 
                 $toDatabase = function (UnitEnum $enum): string {
-                    if (! $enum instanceof $this->enumClass) {
-                        throw ConversionException::conversionFailedInvalidType($enum, $this->name, [$this->enumClass]);
+                    if (! $enum instanceof $this->enumClass) { /* @phpstan-ignore-line */
+                        throw ConversionException::conversionFailedInvalidType($enum, $this->name, [$this->enumClass]); /* @phpstan-ignore-line */
                     }
 
                     return $enum->name;
@@ -159,16 +159,16 @@ class PhpEnumType extends Type
             }
         } else {
             $toPhp = function ($enumValue): Enum {
-                if (! $this->enumClass::isValid($enumValue)) {
-                    throw ConversionException::conversionFailed($enumValue, $this->name);
+                if (! $this->enumClass::isValid($enumValue)) { /* @phpstan-ignore-line */
+                    throw ConversionException::conversionFailed($enumValue, $this->name); /* @phpstan-ignore-line */
                 }
 
-                return new $this->enumClass($enumValue);
+                return new $this->enumClass($enumValue); /* @phpstan-ignore-line */
             };
 
             $toDatabase = function (Enum $enum): string {
-                if (! $enum instanceof $this->enumClass) {
-                    throw ConversionException::conversionFailedInvalidType($enum, $this->name, [$this->enumClass]);
+                if (! $enum instanceof $this->enumClass) { /* @phpstan-ignore-line */
+                    throw ConversionException::conversionFailedInvalidType($enum, $this->name, [$this->enumClass]); /* @phpstan-ignore-line */
                 }
 
                 return (string) $enum;
@@ -186,7 +186,7 @@ class PhpEnumType extends Type
         $type->name = $typeName;
         $type->enumClass = $enumClass;
         $type->type = $enumType;
-        $type->toPhp = $toPhp->bindTo($type, self::class);
+        $type->toPhp = $toPhp->bindTo($type, self::class); /* @phpstan-ignore-line */
         $type->toDatabase = $toDatabase->bindTo($type, self::class);
 
         $multipleEnumType = 'array<' . $typeName . '>';
@@ -198,7 +198,7 @@ class PhpEnumType extends Type
         $type->name = $multipleEnumType;
         $type->enumClass = $enumClass;
         $type->type = $enumType;
-        $type->toPhp = $toPhp->bindTo($type, self::class);
+        $type->toPhp = $toPhp->bindTo($type, self::class); /* @phpstan-ignore-line */
         $type->toDatabase = $toDatabase->bindTo($type, self::class);
         $type->multiple = true;
     }

--- a/tests/Fixtures/Enum/NativeEnum.php
+++ b/tests/Fixtures/Enum/NativeEnum.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Refugis\DoctrineExtra\Tests\Fixtures\Enum;
+
+enum NativeEnum
+{
+    case CASE_ONE;
+    case CASE_TWO;
+}
+
+enum NativeStringEnum: string
+{
+    case CASE_ONE = 'one';
+    case CASE_TWO = 'two';
+}
+
+enum NativeIntEnum: int
+{
+    case CASE_ONE = 1;
+    case CASE_TWO = 2;
+}

--- a/tests/ORM/EntityRepositoryTest.php
+++ b/tests/ORM/EntityRepositoryTest.php
@@ -88,13 +88,8 @@ class EntityRepositoryTest extends TestCase
         $this->repository->findOneByCached([]);
 
         $key = '__'.str_replace(self::INVALID_CACHE_KEY_CHARS, '', get_class($this->repository)).'findOneByCachedf6e6f43434391be8b061460900c36046255187c8';
-        if (method_exists($this->configuration, 'getResultCache')) {
-            $cache = $this->configuration->getResultCache();
-            self::assertTrue($cache->getItem($key)->isHit());
-        } else {
-            $cache = $this->configuration->getResultCacheImpl();
-            self::assertNotFalse($cache->fetch($key));
-        }
+        $cache = $this->configuration->getResultCache();
+        self::assertTrue($cache->getItem($key)->isHit());
 
         self::assertInstanceOf(TestEntity::class, $obj1);
         self::assertEquals(1, $obj1->id);
@@ -132,13 +127,8 @@ class EntityRepositoryTest extends TestCase
         $this->repository->findByCached([]);
 
         $key = '__'.str_replace(self::INVALID_CACHE_KEY_CHARS, '', get_class($this->repository)).'findByCachedf6e6f43434391be8b061460900c36046255187c8';
-        if (method_exists($this->configuration, 'getResultCache')) {
-            $cache = $this->configuration->getResultCache();
-            self::assertTrue($cache->getItem($key)->isHit());
-        } else {
-            $cache = $this->configuration->getResultCacheImpl();
-            self::assertNotFalse($cache->fetch($key));
-        }
+        $cache = $this->configuration->getResultCache();
+        self::assertTrue($cache->getItem($key)->isHit());
 
         self::assertCount(3, $objs);
         self::assertEquals(1, $objs[0]->id);
@@ -254,13 +244,8 @@ class EntityRepositoryTest extends TestCase
         $this->repository->getOneByCached(['id' => 12]);
 
         $key = '__'.str_replace(self::INVALID_CACHE_KEY_CHARS, '', get_class($this->repository)).'getOneByCached48b7e8dc8f3d4c52abba542ba5f3d423da65cf5e';
-        if (method_exists($this->configuration, 'getResultCache')) {
-            $cache = $this->configuration->getResultCache();
-            self::assertTrue($cache->getItem($key)->isHit());
-        } else {
-            $cache = $this->configuration->getResultCacheImpl();
-            self::assertNotFalse($cache->fetch($key));
-        }
+        $cache = $this->configuration->getResultCache();
+        self::assertTrue($cache->getItem($key)->isHit());
 
         self::assertInstanceOf(TestEntity::class, $obj1);
         self::assertEquals(12, $obj1->id);


### PR DESCRIPTION
`PhpEnumType` supports PHP 8.1 enums:
Backed enums are converted to the backed value (string or int), while non-backed enums are converted to the case name.

This would allow a smooth transition from enums provided by `myclabs/php-enum` package to the native ones.